### PR TITLE
Rewrite USB device hotplugging to support composite devices

### DIFF
--- a/src/qextserialenumerator_p.h
+++ b/src/qextserialenumerator_p.h
@@ -87,9 +87,8 @@ public:
     bool setUpNotifications_sys(bool setup);
 
 #if defined(Q_OS_WIN) && defined(QT_GUI_LIB)
-    LRESULT onDeviceChanged(WPARAM wParam, LPARAM lParam);
-    bool matchAndDispatchChangedDevice(const QString &deviceID, const GUID &guid, WPARAM wParam);
     QextSerialRegistrationWidget *notificationWidget;
+    void rescanDevices();
 #endif /*Q_OS_WIN*/
 
 #ifdef Q_OS_MAC
@@ -118,6 +117,9 @@ public:
 
 private:
     QextSerialEnumerator *q_ptr;
+#ifdef Q_OS_WIN
+    QList<QextPortInfo> m_knownDevices;
+#endif // q_os_win
 };
 
 #endif //_QEXTSERIALENUMERATOR_P_H_


### PR DESCRIPTION
In Windows 7/8, our TinyG board shows up as a composite device with two
endpoints. Due to unfathomable reasons, Windows does not send out device
notifications when the endpoints appear, and instead only sends a single
notification that the parent composite device has appeared.

This patch replaces all handling of incremental device add/remove notifications
with a brute force approach. Every time the device tree changes, we wait 100ms
for devices to settle then rescan all devices to find which ones are supported
and emit signals to reflect the change in state.

This is fragile and intended as a stopgap solution until more robust cross
platform hardware detection is implemented with libusb.

This closes Otherplan-1305.
