### PR TITLE
Patches for El Capitan compatibility

### DIFF
--- a/src/qextserialenumerator_osx.cpp
+++ b/src/qextserialenumerator_osx.cpp
@@ -116,25 +116,31 @@ bool QextSerialEnumeratorPrivate::getServiceDetailsOSX(io_object_t service, Qext
     // vendor/product IDs and the product name, if available
     io_registry_entry_t parent;
     kern_return_t kernResult = IORegistryEntryGetParentEntry(service, kIOServicePlane, &parent);
-    while (kernResult == KERN_SUCCESS && !vendorIdAsCFNumber && !productIdAsCFNumber && !serialNumberAsCFString) {
-        if (!productNameAsCFString)
+    while (kernResult == KERN_SUCCESS && !(vendorIdAsCFNumber && productIdAsCFNumber && serialNumberAsCFString)) {
+        if (!productNameAsCFString) {
             productNameAsCFString = IORegistryEntrySearchCFProperty(parent,
                                                                     kIOServicePlane,
                                                                     CFSTR("Product Name"),
                                                                     kCFAllocatorDefault, 0);
-        vendorIdAsCFNumber = IORegistryEntrySearchCFProperty(parent,
-                                                             kIOServicePlane,
-                                                             CFSTR(kUSBVendorID),
-                                                             kCFAllocatorDefault, 0);
-        productIdAsCFNumber = IORegistryEntrySearchCFProperty(parent,
-                                                              kIOServicePlane,
-                                                              CFSTR(kUSBProductID),
-                                                              kCFAllocatorDefault, 0);
-
-        serialNumberAsCFString = IORegistryEntrySearchCFProperty(parent,
-                                                              kIOServicePlane,
-                                                              CFSTR(kUSBSerialNumberString),
-                                                              kCFAllocatorDefault, 0);
+        }
+        if (!vendorIdAsCFNumber) {
+            vendorIdAsCFNumber = IORegistryEntrySearchCFProperty(parent,
+                                                                 kIOServicePlane,
+                                                                 CFSTR(kUSBVendorID),
+                                                                 kCFAllocatorDefault, 0);
+        }
+        if (!productIdAsCFNumber) {
+            productIdAsCFNumber = IORegistryEntrySearchCFProperty(parent,
+                                                                  kIOServicePlane,
+                                                                  CFSTR(kUSBProductID),
+                                                                  kCFAllocatorDefault, 0);
+        }
+        if (!serialNumberAsCFString) {
+            serialNumberAsCFString = IORegistryEntrySearchCFProperty(parent,
+                                                                     kIOServicePlane,
+                                                                     CFSTR(kUSBSerialNumberString),
+                                                                     kCFAllocatorDefault, 0);
+        }
         io_registry_entry_t oldparent = parent;
         kernResult = IORegistryEntryGetParentEntry(parent, kIOServicePlane, &parent);
         IOObjectRelease(oldparent);


### PR DESCRIPTION
Includes:
1) A workaround for an El Capitan bug where open calls to newly enumerated endpoints fail unless preceded by a slight delay. (I have a radar open with Apple for this which they have yet to address.)
2) Fixed getServiceDetails to ensure it retrieves serial IDs for all BSD endpoints. This allows us to sidestep the issue of CDC composite device notifications on El Capitan, because we previously relied on those notifications only for serial IDs. See Otherplan-497 for additional details.

Reviewer: @tdfischer 
